### PR TITLE
Fix Req 58 for dedicated /home volumes

### DIFF
--- a/hardening-linux-server/tasks/linux(06)compliance-checks.yml
+++ b/hardening-linux-server/tasks/linux(06)compliance-checks.yml
@@ -70,7 +70,7 @@
     owner: "{{ item }}"
     group: "{{ item }}"
     mode: o-rwx
-  with_items: "{{ user_dirs.stdout_lines | default([]) }}"
+  with_items: "{{ user_dirs.stdout_lines | difference(['lost+found']) | default([]) }}"
   when: config_req_58 | default(true)
 
 # Req-59: Default group for the root account must be GID 0.


### PR DESCRIPTION
When /home is a dedicated volume, 058.1 will abort with "failed to lookup user lost+foun" (or similar). Fixed by excluding lost+found from user list.