### PR TITLE
Fix check-mode for {cron.at}.allow

### DIFF
--- a/hardening-linux-server/tasks/linux(01)basic-hardening.yml
+++ b/hardening-linux-server/tasks/linux(01)basic-hardening.yml
@@ -301,6 +301,7 @@
   when: 
     - config_req_07 | default(true)
     - authorized_user_for_cron_at | length > 0
+    - not ansible_check_mode
     
 # Req-8: Sticky bit must be set on all world-writable directories.
 


### PR DESCRIPTION
Prevent fatal error when no {cron.at}.allow is present on system by skipping the second step of req-007.2 when in check mode